### PR TITLE
NL/Make ID partitioner failsafe

### DIFF
--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/IdPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/IdPartitioner.java
@@ -38,7 +38,7 @@ public class IdPartitioner<T> extends DefaultPartitioner<T> {
         try {
             return encodeWithId(sinkRecord);
         } catch (Exception e) {
-            log.error(
+            log.warn(
                 String.format("IdPartitioner threw an exception: consult the malformed event at '%s%s%s%s%s%s%s.json'",
                     fallback,
                     this.delim,

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/IdPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/IdPartitioner.java
@@ -1,9 +1,7 @@
 package io.confluent.connect.storage.partitioner;
 
+import io.confluent.connect.storage.common.StorageCommonConfig;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,25 +9,50 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 
-import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.errors.PartitionException;
-
 import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 
 public class IdPartitioner<T> extends DefaultPartitioner<T> {
     private static final Logger log = LoggerFactory.getLogger(IdPartitioner.class);
-    private List<String> fieldNames;
     private static final String PURPOSE = "Partitioning topic into s3 with key value";
+
+    private List<String> fieldNames;
+    private String fileDelim;
+    private String fallback;
 
     @SuppressWarnings("unchecked")
     @Override
     public void configure(Map<String, Object> config) {
         fieldNames = (List<String>) config.get(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG);
         delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+        fileDelim = (String) config.get(StorageCommonConfig.FILE_DELIM_CONFIG);
+        fallback = (String) config.get(PartitionerConfig.ID_PARTITIONER_ERROR_FALLBACK_CONFIG);
+    }
+
+    @Override
+    public String generatePartitionedPath(String topic, String encodedPartition) {
+        return encodedPartition;
     }
 
     @Override
     public String encodePartition(SinkRecord sinkRecord) {
+        try {
+            return encodeWithId(sinkRecord);
+        } catch (Exception e) {
+            log.error(
+                String.format("IdPartitioner threw an exception: consult the malformed event at '%s%s%s%s%s%s%s.json'",
+                    fallback,
+                    this.delim,
+                    sinkRecord.topic(),
+                    fileDelim,
+                    sinkRecord.kafkaPartition(),
+                    fileDelim,
+                    sinkRecord.kafkaOffset()),
+                e);
+            return fallback;
+        }
+    }
+
+    private String encodeWithId(SinkRecord sinkRecord) {
         Object value = sinkRecord.value();
         log.info(value.toString());
 

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/IdPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/IdPartitioner.java
@@ -46,7 +46,7 @@ public class IdPartitioner<T> extends DefaultPartitioner<T> {
                     fileDelim,
                     sinkRecord.kafkaPartition(),
                     fileDelim,
-                    sinkRecord.kafkaOffset()),
+                    String.format("%010d", sinkRecord.kafkaOffset())),
                 e);
             return fallback;
         }

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.storage.partitioner;
 
+import io.confluent.connect.storage.common.ComposableConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -26,8 +27,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import io.confluent.connect.storage.common.ComposableConfig;
 
 public class PartitionerConfig extends AbstractConfig implements ComposableConfig {
 
@@ -101,6 +100,12 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
       "The record field to be used as timestamp by the timestamp extractor.";
   public static final String TIMESTAMP_FIELD_NAME_DEFAULT = "timestamp";
   public static final String TIMESTAMP_FIELD_NAME_DISPLAY = "Record Field for Timestamp Extractor";
+
+  public static final String ID_PARTITIONER_ERROR_FALLBACK_CONFIG = "partition.error.fallback";
+  public static final String ID_PARTITIONER_ERROR_FALLBACK_DOC =
+      "A static value to encode the partition if the ID Partitioner failed";
+  public static final String ID_PARTITIONER_ERROR_FALLBACK_DEFAULT = "_MALFORMED";
+  public static final String ID_PARTITIONER_ERROR_FALLBACK_DISPLAY = "ID Partitioner Error Fallback";
 
   /**
    * Create a new configuration definition.
@@ -209,6 +214,16 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
           ++orderInGroup,
           Width.LONG,
           TIMESTAMP_FIELD_NAME_DISPLAY);
+
+      configDef.define(ID_PARTITIONER_ERROR_FALLBACK_CONFIG,
+              Type.STRING,
+              ID_PARTITIONER_ERROR_FALLBACK_DEFAULT,
+              Importance.MEDIUM,
+              ID_PARTITIONER_ERROR_FALLBACK_DOC,
+              group,
+              ++orderInGroup,
+              Width.LONG,
+              ID_PARTITIONER_ERROR_FALLBACK_DISPLAY);
     }
 
     return configDef;


### PR DESCRIPTION
# Make ID partitioner failsafe

The task [FOR-1230](https://mon-data.atlassian.net/browse/FOR-1230) requires sinking Kafka events into S3. 

A PR [adds the datalake bucket](https://github.com/Elucidia/f2s-infrastructure/pull/9) and another [fixes the S3 task](https://github.com/Elucidia/kafka-connect-worker/pull/41).

The config `partition.error.fallback` was added to set the name of the folder if no id is available. The error is also logged with a reference to the faulty event. The topic is ignored when encoding.


## Local test

We can see three folders [in the s3 bucket](https://s3.console.aws.amazon.com/s3/buckets/nl-test-kafka-connect-datalake/?region=ca-central-1&tab=overview) : two for different orgs and one for events with no OrganizationId
![firefox_p3h9d1yr4o](https://user-images.githubusercontent.com/69467772/94847070-15efbf00-03f0-11eb-8425-32d5e9815988.png)

Inside one of the folder (azdev1), we can see many topics are recorded in here.
![image](https://user-images.githubusercontent.com/69467772/94847030-0f614780-03f0-11eb-8cca-70b2079dff2f.png)

```
[2020-10-01 17:55:27,701] INFO {test=true} (io.confluent.connect.storage.partitioner.IdPartitioner:57)
[2020-10-01 17:55:27,701] WARN IdPartitioner threw an exception: consult the malformed event at '_NoOrganizationId/test-nl+1+0000000004.json' (io.confluent.connect.storage.partitioner.IdPartitioner:41)
org.apache.kafka.connect.errors.DataException: Only Map objects supported in absence of schema for [Partitioning topic into s3 with key value], found: null
        at org.apache.kafka.connect.transforms.util.Requirements.requireMap(Requirements.java:38)
        at io.confluent.connect.storage.partitioner.IdPartitioner.encodeWithId(IdPartitioner.java:59)
        at io.confluent.connect.storage.partitioner.IdPartitioner.encodePartition(IdPartitioner.java:39)
        at io.confluent.connect.storage.partitioner.Partitioner.encodePartition(Partitioner.java:49)
        at io.confluent.connect.s3.TopicPartitionWriter.executeState(TopicPartitionWriter.java:213)
        at io.confluent.connect.s3.TopicPartitionWriter.write(TopicPartitionWriter.java:189)
        at io.confluent.connect.s3.S3SinkTask.put(S3SinkTask.java:190)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:538)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:224)
        at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:192)
        at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:175)
        at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:219)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
[2020-10-01 17:55:27,706] INFO Starting commit and rotation for topic partition test-nl-1 with start offset {_NoOrganizationId=4} (io.confluent.connect.s3.TopicPartitionWriter:278)
```